### PR TITLE
Update docs.css document tabs colors

### DIFF
--- a/src/firefox/docs.css
+++ b/src/firefox/docs.css
@@ -121,6 +121,14 @@ BELOW CSS CLASSES APPEAR TO BE GENERATED, VOLATILE
   color: var(--primary-text-color);
 }
 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-0, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-1, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-2, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-3, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-4, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-5, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-6, 
+.outlines-widget .outlines-widget-chaptered .chapter-container .navigation-item .navigation-item-level-7,
 input,
 .docs-title-input:focus,
 .docs-gm .modal-dialog .jfk-textinput,

--- a/src/firefox/docs.css
+++ b/src/firefox/docs.css
@@ -895,7 +895,12 @@ body.docs-gm:not(.docs-grille-gm3)
 }
 
 /* PRIMARY BORDER BACKGROUND */
-
+.outlines-widget-chaptered .navigation-item:not(.navigation-item:last-child) .navigation-item-vertical-line-bottom,
+.outlines-widget-chaptered .navigation-item:not(.navigation-item.location-indicator-highlight) .navigation-item-vertical-line-middle,
+.outlines-widget-chaptered .navigation-item:not(.navigation-item:last-child) .navigation-item-vertical-line-top,
+.outlines-widget-chaptered .navigation-item:last-child .navigation-item-vertical-line-bottom,
+.outlines-widget-chaptered .navigation-item:last-child .navigation-item-vertical-line-middle,
+.outlines-widget-chaptered .navigation-item:last-child .navigation-item-vertical-line-top,
 .docos-xeditor .docos-streamdocoview-header-container,
 .kix-smart-summary-view-separator {
   background-color: var(--primary-border-color);
@@ -1655,6 +1660,8 @@ span.docs-material-gm-checkbox-checked.docs-material-gm-checkbox-focused,
 
 /* BUTTONS */
 
+.chapter-item-label-and-buttons-container-selected,
+.chapter-item-label-and-buttons-container-selected:focus-within,
 .docs-material-button-fill-primary.docs-material-button,
 .docs-gm .modal-dialog .goog-buttonset-action,
 .docs-gm .modal-dialog .jfk-button-action,
@@ -1666,6 +1673,7 @@ span.docs-material-gm-checkbox-checked.docs-material-gm-checkbox-focused,
   background: var(--button-background-color);
 }
 
+.outlines-widget-chaptered .kix-outlines-widget-header-contents,
 .docs-gm .modal-dialog button,
 .docs-gm .modal-dialog .jfk-button-standard,
 .docs-material-button-hairline-primary.docs-material-button,
@@ -1673,6 +1681,7 @@ span.docs-material-gm-checkbox-checked.docs-material-gm-checkbox-focused,
   background: var(--button-two-background-color);
 }
 
+.outlines-widget-chaptered .kix-outlines-widget-header-contents,
 .docs-gm .modal-dialog button:hover,
 .docs-gm .modal-dialog .jfk-button-standard.jfk-button-hover,
 .docs-gm .modal-dialog button:active,
@@ -1693,6 +1702,8 @@ span.docs-material-gm-checkbox-checked.docs-material-gm-checkbox-focused,
   background: var(--button-two-background-color-hover);
 }
 
+.chapter-item-label-and-buttons-container-selected,
+.chapter-item-label-and-buttons-container-selected:focus-within,
 .docs-gm .modal-dialog .goog-buttonset-action:hover,
 .docs-gm .modal-dialog .jfk-button-action.jfk-button-hover,
 .docs-gm .docs-material-bubble .jfk-button-action.jfk-button-hover,


### PR DESCRIPTION
Aspires to close #65 

Offered this code only as a guide for codeowners, as I'm sure it is missing a lot of stuff. Please take/use/improve as much as needed.

## TODOs
- [x] Bare minimum styles for eye relief
- [ ] All browsers
- [ ] All style options (default, shade, dark, black, etc)
- [ ] Hover, active, selected, nonselected styles
- [ ] images/icons
- [ ] tests?

## Screencaps

Screenshot below is out of date; the chapter labels have been brightened to `--primary-text-color`.
<details><summary>peep :eyes:</summary>

![image](https://github.com/user-attachments/assets/6f8dc28f-17f9-462c-991c-818e89658661)

</details>