### PR TITLE
add support for gemini sidebar

### DIFF
--- a/src/assets/css/docs.css
+++ b/src/assets/css/docs.css
@@ -720,7 +720,7 @@ div[style="background: #F0F6FF; border: 1px solid black; margin-top: 35px; paddi
 .companion-collapser-button.app-switcher-button-checked .app-switcher-button-icon-background, .companion-theme-light .companion-collapser-button.app-switcher-button-checked .app-switcher-button-icon-background,
 .jfk-bubble,
 .docs-grille-gm3 .docs-ui-toast,
-/* .javascriptMaterialdesignGm3WizMenuSurface-menu-surface, */
+.javascriptMaterialdesignGm3WizMenuSurface-menu-surface,
 .ita-hwt-ime,
 .ita-hwt-candidates,
 .docsContentLibrarySidebarContainer,


### PR DESCRIPTION
Add support for inversion and background coloring in the gemini sidebar and fix an issue where the @filename tooltip menu in the gemini prompt field was not property inverted