### PR TITLE
Feature: Add Preserve colors option in dark mode

### DIFF
--- a/src/docs.ts
+++ b/src/docs.ts
@@ -405,11 +405,8 @@ class DocsAfterDark {
             case InvertMode.Black:
                 setStyleProperty("documentInvert", documentInvert.black);
                 break;
-            case InvertMode.Preserve_colors:
-                setStyleProperty(
-                    "documentInvert",
-                    documentInvert.preserve_colors
-                );
+            case InvertMode.Colorful:
+                setStyleProperty("documentInvert", documentInvert.colorful);
                 break;
             case InvertMode.Normal:
                 setStyleProperty("documentInvert", documentInvert.normal);

--- a/src/popup.html
+++ b/src/popup.html
@@ -186,16 +186,16 @@
                                     id="invertOptions"
                                     class="buttonRow fullWidth"
                                 >
+                                    <button id="documentInvertColorful">
+                                        <span>Colorful</span>
+                                    </button>
+
                                     <button id="documentInvertGray">
                                         <span>Gray</span>
                                     </button>
 
                                     <button id="documentInvertBlack">
                                         <span>Black</span>
-                                    </button>
-
-                                    <button id="documentInvertPreserveColors">
-                                        <span>Preserve Colors</span>
                                     </button>
 
                                     <button id="documentInvertOff">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -128,6 +128,7 @@ class ModeComponent extends StateSubscriber {
                             mode: ExtensionMode.Dark,
                             doc_bg: DocumentBackground.Blend,
                             invert_enabled: true,
+                            invert_mode: defaultExtensionData.invert_mode,
                         });
                         break;
                     case "light":
@@ -470,8 +471,8 @@ class InvertComponent extends StateSubscriber {
     private blackButton = document.querySelector(
         "#documentInvertBlack"
     ) as HTMLButtonElement;
-    private preserveColorsButton = document.querySelector(
-        "#documentInvertPreserveColors"
+    private colorfulButton = document.querySelector(
+        "#documentInvertColorful"
     ) as HTMLButtonElement;
     private offButton = document.querySelector(
         "#documentInvertOff"
@@ -503,9 +504,9 @@ class InvertComponent extends StateSubscriber {
             });
         });
 
-        this.preserveColorsButton.addEventListener("click", () => {
+        this.colorfulButton.addEventListener("click", () => {
             this.state.setData({
-                invert_mode: InvertMode.Preserve_colors,
+                invert_mode: InvertMode.Colorful,
                 invert_enabled: true,
             });
         });
@@ -533,8 +534,8 @@ class InvertComponent extends StateSubscriber {
             case InvertMode.Black:
                 this.blackButton.classList.add("selected");
                 break;
-            case InvertMode.Preserve_colors:
-                this.preserveColorsButton.classList.add("selected");
+            case InvertMode.Colorful:
+                this.colorfulButton.classList.add("selected");
                 break;
             case InvertMode.Normal:
                 this.normalButton.classList.add("selected");
@@ -547,7 +548,7 @@ class InvertComponent extends StateSubscriber {
     resetAppearance(): void {
         this.grayButton.classList.remove("selected");
         this.blackButton.classList.remove("selected");
-        this.preserveColorsButton.classList.remove("selected");
+        this.colorfulButton.classList.remove("selected");
         this.normalButton.classList.remove("selected");
         this.offButton.classList.remove("selected");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ enum InvertMode {
     Normal = 0,
     Gray = 1,
     Black = 2,
-    Preserve_colors = 3,
+    Colorful = 3,
 }
 
 ////////////////////

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,11 @@ import {
     type MessageListener,
     type StorageListener,
 } from "./types";
-import { SELECTOR_PREFIX, STYLE_PROPERTY_PREFIX } from "./values";
+import {
+    defaultExtensionData,
+    SELECTOR_PREFIX,
+    STYLE_PROPERTY_PREFIX,
+} from "./values";
 
 declare const browser: BrowserAPI;
 declare const chrome: BrowserAPI;
@@ -268,8 +272,8 @@ function updateExtensionData(data: ExtensionData): ExtensionData {
         if (data.invert.black) {
             data.invert_mode = InvertMode.Black;
         } else {
-            // If was previously using normal invert mode, convert to grayscale
-            data.invert_mode = InvertMode.Gray;
+            // If was previously using normal invert mode, convert to default
+            data.invert_mode = defaultExtensionData.invert_mode;
         }
 
         deleteStorage("invert");

--- a/src/values.ts
+++ b/src/values.ts
@@ -55,7 +55,7 @@ const documentInvert = {
     normal: "invert(1)",
     grayscale: "invert(1) contrast(79.5%) grayscale(100%)",
     black: "invert(1) grayscale(100%)",
-    preserve_colors: "invert(1) hue-rotate(180deg)",
+    colorful: "invert(1) hue-rotate(180deg)",
     off: "none",
 };
 
@@ -82,7 +82,7 @@ const defaultExtensionData: ExtensionData = {
     accent_color: { hue: 225 },
 
     invert_enabled: true,
-    invert_mode: InvertMode.Preserve_colors,
+    invert_mode: InvertMode.Colorful,
 
     button_options: {
         show: true,


### PR DESCRIPTION
**_Note: This is a re-implementation of the preserve-colors feature proposed in [#106](https://github.com/waymondrang/docsafterdark/pull/106) to resolve conflicts introduced by @waymondrang in the redesign._**

# Problem
The Invert checkbox inverts all colored text in the Google doc.

However, this is very unintuitive since you'll have to guess at the opposite color if you want to set the text to a particular color - e.g. for green text, you'll have to set it to magenta.

This was referenced in these issues: 
https://github.com/waymondrang/docsafterdark/issues/95
https://github.com/waymondrang/docsafterdark/issues/77

# Feature
Add a "Preserve Colors" checkbox to prevent colored text from being inverted in dark mode.
<img width="328" height="578" alt="Screenshot 2026-01-24 at 20 31 16" src="https://github.com/user-attachments/assets/596117a0-e616-4d51-a093-adc3cf5b407d" />

This keeps the existing text hues as they are and allows only the brightness to change so only black and white text get flipped as usual.

# Code Changes
1. `src/types.ts` - add a new flag to `InvertMode`.
2. `src/values.ts` - add the new invert mode and set that as the default option (This is the default behaviour most users would naturally expect from dark mode - people don't want everything to be turned to grayscale).
3. `src/docs.ts` - add new case for preserve_colors option.
4. `src/popup.html` - added new "Preserve Colors" alongside existing "Gray" and "Black" in UI. 
5. `src/popup.ts` - implement event listener and button element.

P.S: Please don't make any other changes before merging this (unless there's no conflicts obviously) - I really don't want to have to keep reimplmenting the feature over and over just to keep up with changes. Thanks 🙏🏻