### PR TITLE
Cleanup: Disable Invert options in Light Mode

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -178,7 +178,7 @@
                             </div>
                         </div>
 
-                        <div class="section">
+                        <div id="documentInvertSection" class="section">
                             <h3 class="sectionTitle">Invert</h3>
 
                             <div class="sectionContent">
@@ -278,20 +278,6 @@
                                             <span>Show</span>
                                         </div>
                                     </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="section">
-                            <h3 class="sectionTitle">Invert</h3>
-                            <div class="sectionContent">
-                                <div
-                                    id="advancedInvertOptions"
-                                    class="buttonRow fullWidth"
-                                >
-                                    <button id="documentInvertNormal">
-                                        <span>Normal</span>
-                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -464,6 +464,10 @@ class TipComponent {
 }
 
 class InvertComponent extends StateSubscriber {
+    private section = document.querySelector(
+        "#documentInvertSection"
+    ) as HTMLDivElement;
+
     private grayButton = document.querySelector(
         "#documentInvertGray"
     ) as HTMLButtonElement;
@@ -472,11 +476,6 @@ class InvertComponent extends StateSubscriber {
     ) as HTMLButtonElement;
     private offButton = document.querySelector(
         "#documentInvertOff"
-    ) as HTMLButtonElement;
-
-    // In advanced settings category
-    private normalButton = document.querySelector(
-        "#documentInvertNormal"
     ) as HTMLButtonElement;
 
     initialize(): void {
@@ -499,16 +498,18 @@ class InvertComponent extends StateSubscriber {
                 invert_enabled: true,
             });
         });
-
-        this.normalButton.addEventListener("click", () => {
-            this.state.setData({
-                invert_mode: InvertMode.Normal,
-                invert_enabled: true,
-            });
-        });
     }
 
     update(newData: ExtensionData): void {
+        const isDarkMode = newData.mode === ExtensionMode.Dark;
+
+        // Show invert options only in dark mode
+        if (isDarkMode) {
+            this.section.classList.remove("hidden");
+        } else {
+            this.section.classList.add("hidden");
+        }
+
         this.resetAppearance();
 
         if (!newData.invert_enabled) {
@@ -524,7 +525,7 @@ class InvertComponent extends StateSubscriber {
                 this.blackButton.classList.add("selected");
                 break;
             case InvertMode.Normal:
-                this.normalButton.classList.add("selected");
+                this.offButton.classList.add("selected");
                 break;
             default:
                 break;
@@ -534,7 +535,6 @@ class InvertComponent extends StateSubscriber {
     resetAppearance(): void {
         this.grayButton.classList.remove("selected");
         this.blackButton.classList.remove("selected");
-        this.normalButton.classList.remove("selected");
         this.offButton.classList.remove("selected");
     }
 }


### PR DESCRIPTION
# Cleanup
Light mode currently is cluttered and there are some really unnecessary bits that both clutter the UI and the codebase itself.

First of all, the whole point of this chrome extension is to add dark mode - which naturally assumes that Google Docs is already in "Light mode".

This makes the Light Mode setting entirely redundant (apart from perhaps slight UI shading customisations that the user can change).

But besides that point, with the current lightmode, it has the invert options which invert black text to white - completely useless when text is naturally black in Light mode anyways.

And secondly, there is also an invert option that is completely useless since all it does in lightmode is invert the colored text - why a user would want to deliberately mess up their own document's colors?

So in this commit, I hide the Invert options entirely in Light mode and also remove the invert option in the advanced settings. This keeps the existing behaviour in the UI and cuts down the unnecessary bloat in the codebase.