### PR TITLE
patch: update readme, remove --check from package.ts, update npm run build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,15 @@ A free and open-source browser extension for customizing the appearance of Googl
 ## Features
 
 - Modern, sleek dark mode
-- Colorful light mode
+    - Normal and midnight variants
+- Vibrant light mode
 - Customizable accent color
-- Quick toggle button
+- Adjustable document background (unstable)
+- Colorful and grayscale document invert (may affect images)
+- Toggleable document border
+- Quick toggle button (removable)
 - Accessible settings popup
-
-### Customization
-
-- Choose between Normal and Midnight dark mode variants
-- Change the highlight accent color hue for both dark and light mode
-- Set the document background (may be unstable on Chromium-based browsers)
-    - **Default** - white
-    - **Shade** - tinted in light mode
-    - **Blend** - transparent
-    - **Black** - #000000
-    - **Custom** - specify your own CSS value
-- Display document content in dark mode with invert options (may invert images)
-- Remove the document border for a seamless workspace
-- Disable or move the toggle button
+- Non-destructive
 
 ### Quick toggle button
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "homepage": "https://docsafterdark.com/",
     "scripts": {
-        "build": "webpack --mode=production && ts-node package.ts --check && sass src/scss/docs.scss build/docs.bundle.css && sass src/scss/frame.scss build/frame.bundle.css && sass src/scss/global.scss build/global.bundle.css && web-ext lint --source-dir=build && ts-node package.ts",
+        "build": "webpack --mode=production && sass src/scss/docs.scss build/docs.bundle.css && sass src/scss/frame.scss build/frame.bundle.css && sass src/scss/global.scss build/global.bundle.css && web-ext lint --source-dir=build && ts-node package.ts",
         "check": "prettier --check . && eslint src && stylelint '**/*.scss'",
         "dev": "concurrently --names 'webpack,sass,sass,sass' --prefix-colors 'magenta,red,blue,yellow' 'webpack --watch' 'sass --watch src/scss/docs.scss build/docs.bundle.css' 'sass --watch src/scss/frame.scss build/frame.bundle.css' 'sass --watch src/scss/global.scss build/global.bundle.css'",
         "firefox": "web-ext run --source-dir build/ --keep-profile-changes",

--- a/package.ts
+++ b/package.ts
@@ -234,22 +234,10 @@ async function packageExtension(
 
 const args = process.argv.slice(2);
 const withForce = args.includes("--force") || args.includes("-f");
-const onlyPackageCheck = args.includes("--check") || args.includes("-c");
+
+// NOTE: Passing args from npm run build -- only works if package.ts is the
+//       last command in the script.
 
 const manifest = getManifest();
-const version = manifest.version;
-
-if (onlyPackageCheck) {
-    const zipFilePath = getZipFilePath(version);
-
-    if (existsSync(zipFilePath)) {
-        Logger.warn(
-            `Package already exists: ${zipFilePath}. Use --force flag to overwrite existing package.`
-        );
-        process.exit(1);
-    }
-
-    process.exit(0);
-}
 
 packageExtension(manifest, withForce);


### PR DESCRIPTION
--check does not work because the invocation of package.ts is in the middle of the `npm run build` script, meaning the flags are not passed to it.

simplify readme by removing redundant information