### PR TITLE
feature: per-document settings

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -56,6 +56,33 @@
 
             <div class="category">
                 <div class="categoryContent">
+                     <div class="section">
+                        <div class="sectionContent">
+                            <div class="checkboxRow">
+                                <label
+                                    class="checkboxButton"
+                                    for="documentEnabled"
+                                >
+                                    <input
+                                        type="checkbox"
+                                        id="documentEnabled"
+                                        name="documentEnabled"
+                                        enabled
+                                    />
+
+                                    <span class="checkbox"></span>
+                                    <span class="content">
+                                        <span>Enable for this document</span>
+                                    </span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="category">
+                <div class="categoryContent">
                     <div class="section">
                         <h3 class="sectionTitle">Global Toggle</h3>
 

--- a/src/scss/popup/_generic.scss
+++ b/src/scss/popup/_generic.scss
@@ -5,6 +5,7 @@
 .disabled {
     opacity: 0.25;
     cursor: not-allowed;
+    pointer-events: none;
 }
 
 .flexRow {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ type ExtensionData = {
     invert_mode: InvertMode;
 
     show_border: boolean;
+    disabled_documents: Array<string>;
 
     accent_color: AccentColorOptions;
     button_options: ButtonOptions;
@@ -125,7 +126,8 @@ type StorageListener = (
 
 interface MessagePayload {
     type: string;
-    color: AccentColorOptions;
+    color?: AccentColorOptions;
+    enabled?: boolean;
 }
 
 type MessageListener = (
@@ -143,11 +145,13 @@ interface ListenerFunctions<T> {
 interface QueryInfo {
     active?: boolean;
     currentWindow?: boolean;
+    lastFocusedWindow?: boolean;
 }
 
 interface Tab {
     active: boolean;
     id?: number;
+    url?: string;
 }
 
 interface CreateProperties {

--- a/src/util.ts
+++ b/src/util.ts
@@ -168,6 +168,7 @@ async function getExtensionData(): Promise<ExtensionData> {
         "doc_bg",
         "custom_bg",
         "show_border",
+        "disabled_documents",
         "accent_color",
         "button_options",
         "invert_enabled",
@@ -213,6 +214,22 @@ function removeClassFromHTML(...classes: string[]): void {
     document.documentElement.classList.remove(
         ...classes.map((c) => SELECTOR_PREFIX + c)
     );
+}
+
+function getDocumentID(url: string) {
+    return url?.split('/document/d/')[1]?.split('/')[0] ?? url;
+}
+
+async function isDisabledDocument(url: string): Promise<boolean> {
+    var data = await getExtensionData();
+    var document_id = getDocumentID(url);
+    if (data.disabled_documents?.includes(document_id)) return true;
+    return false;
+}
+
+async function getActiveURL(): Promise<string> {
+    const [tab] = await browser_ns.tabs.query({active: true, lastFocusedWindow: true});
+    return tab?.url ?? "";
 }
 
 function isOnHomepage(): boolean {
@@ -305,6 +322,9 @@ export {
     addClassToHTML,
     removeClassFromHTML,
     isOnHomepage,
+    isDisabledDocument,
+    getActiveURL,
+    getDocumentID,
     getElementId,
     removeElement,
     hasElement,

--- a/src/values.ts
+++ b/src/values.ts
@@ -96,6 +96,7 @@ const defaultExtensionData: ExtensionData = {
     },
 
     show_border: true,
+    disabled_documents: [],
 
     version: {
         last_version: "",


### PR DESCRIPTION
Proposed functionality for allowing the plugin to be disabled on specific documents.
Main changes:

- Main functionality works by interrupting function updateExtension in docs.ts
- Edits ExtensionData schema to store document IDs (portion of URL unique to document)
- hooks into MessagePayload to enable realtime change

Known bugs and improvements:

- Still attempts to store data about non google docs pages
- Disabling for a document visually applies only to the active tab (correctly applied if reloading)
- An option (probably in advanced settings) should be added to clear the cache in case it stores too many documents
- Several functions had to be changed to async to work which may have a performance impact

Related to #119 