### PR TITLE
Fixes #138: Context Menu uses Google defined colors

### DIFF
--- a/src/scss/base/_base.scss
+++ b/src/scss/base/_base.scss
@@ -1446,7 +1446,7 @@ div[style="background: #F0F6FF; border: 1px solid black; margin-top: 35px; paddi
 // BACKGROUND: MENU BACKGROUND COLOR //
 ///////////////////////////////////////
 
-.goog-menu {
+.docs-gm .goog-menu {
     background: var(--menu-background);
 }
 


### PR DESCRIPTION
Resolves #135 #136 #137 #138

## Overview
Prefixes `.goog-menu` selector with `.docs-gm` to overwrite identical selector from Google side.

## Testing
Tested in
- Firefox `147.0.4`
- Chrome `145.0.7632.76`